### PR TITLE
Complete the incomplete integration of Vocabulary with Chooser

### DIFF
--- a/build/vue-loader.conf.js
+++ b/build/vue-loader.conf.js
@@ -7,10 +7,15 @@ const sourceMapEnabled = isProduction
   : config.dev.cssSourceMap
 
 module.exports = {
-  loaders: utils.cssLoaders({
-    sourceMap: sourceMapEnabled,
-    extract: isProduction
-  }),
+  loaders: Object.assign({},
+    utils.cssLoaders({
+      sourceMap: sourceMapEnabled,
+      extract: isProduction
+    }),
+    {
+      i18n: '@kazupon/vue-i18n-loader'
+    }
+  ),
   cssSourceMap: sourceMapEnabled,
   cacheBusting: config.dev.cacheBusting,
   transformToRequire: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,9 +167,9 @@
       }
     },
     "@creativecommons/vocabulary": {
-      "version": "0.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@creativecommons/vocabulary/-/vocabulary-0.0.0-alpha.9.tgz",
-      "integrity": "sha512-mU7cbUjoVsVjkhFzuAwAcQMTCOpqI24bi4NERpjjBP9AgyAiPBH0Xo4w6j3JtDrIM3Nc6F7wSCxyMRVNAFH4dQ=="
+      "version": "0.0.0-alpha.21",
+      "resolved": "https://registry.npmjs.org/@creativecommons/vocabulary/-/vocabulary-0.0.0-alpha.21.tgz",
+      "integrity": "sha512-nxaLqRAEHclhNv5NqnAOKSmqKg/J/qN0kxfYSuFUfoGzoqNDhUnDn6lGVIOBCipkgbs8LuDC+wqIahkCy3WUkw=="
     },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.21",
@@ -196,6 +196,44 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.6.tgz",
       "integrity": "sha512-HAGRbrOuGDwwUmCYdpzR0hhNQ3EE30dOS4JiJKcoZ+S4M210CxyU0OXCgzIg3HzK/23rlpHbV8zi9PDDZDnuIw=="
+    },
+    "@kazupon/vue-i18n-loader": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@kazupon/vue-i18n-loader/-/vue-i18n-loader-0.4.1.tgz",
+      "integrity": "sha512-hVznmhnyoUKozGY7pwq/UtPL76UDzb+aiN2YksZZIzCY/MkEqih0MSyEmTGw7+HVWzJRPAlDyoRNR4tWKmkCRw==",
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "json5": "^2.1.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
     },
     "@types/node": {
       "version": "8.10.51",
@@ -708,7 +746,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -15080,8 +15117,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -16173,6 +16209,11 @@
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.3.tgz",
       "integrity": "sha512-KmvZVtmM26BQOMK1rwUZsrqxEGeKiYSZGA7SNWE6uExx8UX/cj9hq2MRV/wWC3Cq6AoeDGk57rL9YMFRel/q+g==",
       "dev": true
+    },
+    "vue-i18n": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.14.0.tgz",
+      "integrity": "sha512-utI1Rvc8i+fmmUkkKRmHaf4QQ87s7rGVL5ZZLsKvvRzmgaIr1l+GfGxxxRmsZxHpPlgeB8OxoUZ4noqZgDL6xg=="
     },
     "vue-jest": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -14,16 +14,18 @@
     "build": "node build/build.js"
   },
   "dependencies": {
-    "@creativecommons/vocabulary": "0.0.0-alpha.9",
+    "@creativecommons/vocabulary": "0.0.0-alpha.21",
     "@fortawesome/fontawesome-svg-core": "^1.2.21",
     "@fortawesome/free-brands-svg-icons": "^5.10.1",
     "@fortawesome/vue-fontawesome": "^0.1.6",
+    "@kazupon/vue-i18n-loader": "^0.4.1",
     "buefy": "^0.7.10",
     "bulma": "^0.7.5",
     "clipboard": "^2.0.4",
     "sass-loader": "^7.1.0",
     "vue": "^2.5.2",
-    "vue-head": "^2.1.2"
+    "vue-head": "^2.1.2",
+    "vue-i18n": "^8.14.0"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
     <div id="app">
-        <Header appName="cc-chooser"/>
+        <Header :title="$t('chooser')"/>
         <div class="container" id="site-container">
             <Chooser v-model="selected"/>
             <hr>
@@ -8,14 +8,20 @@
             <hr>
             <HTMLGenerator :shortLicenseName="selected.shortName"/>
         </div>
-        <Footer/>
+        <Footer>
+            <Locale/>
+        </Footer>
     </div>
 </template>
 <script>
+// TODO Reduce custom styling in favour of Vocabulary styles
+import '@creativecommons/vocabulary/root.css'
+import '@creativecommons/vocabulary/vocabulary.css'
+
 import Chooser from './components/Chooser'
 import HelpSection from './components/HelpSection'
 import HTMLGenerator from './components/HTMLGenerator'
-import { Header, Footer, LicenseIconography } from '@creativecommons/vocabulary'
+import { Header, Footer, LicenseIconography, Locale } from '@creativecommons/vocabulary'
 
 export default {
     name: 'App',
@@ -25,13 +31,14 @@ export default {
         HTMLGenerator,
         Header,
         Footer,
-        LicenseIconography
+        LicenseIconography,
+        Locale
     },
     data() {
         return {
             selected: {
-                shortName: "CC BY 4.0",
-                fullName: "Attribution 4.0 International"
+                shortName: 'CC BY 4.0',
+                fullName: 'Attribution 4.0 International'
             }
         }
     },
@@ -77,3 +84,6 @@ hr {
     }
 }
 </style>
+
+<i18n src="./locales/App.json">
+</i18n>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,23 @@
+import Vue from 'vue'
+import VueI18n from 'vue-i18n'
+
+Vue.use(VueI18n)
+
+function loadLocaleMessages() {
+    const locales = require.context('./locales', true, /[A-Za-z0-9-_,\s]+\.json$/i)
+    const messages = {}
+    locales.keys().forEach(key => {
+        const matched = key.match(/([A-Za-z0-9-_]+)\./i)
+        if (matched && matched.length > 1) {
+            const locale = matched[1]
+            messages[locale] = locales(key)
+        }
+    })
+    return messages
+}
+
+export default new VueI18n({
+    locale: process.env.VUE_APP_I18N_LOCALE || 'en',
+    fallbackLocale: process.env.VUE_APP_I18N_FALLBACK_LOCALE || 'en',
+    messages: loadLocaleMessages()
+})

--- a/src/locales/App.json
+++ b/src/locales/App.json
@@ -1,0 +1,8 @@
+{
+    "en": {
+        "chooser": "Chooser"
+    },
+    "hi": {
+        "chooser": "चयनकर्ता"
+    }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import Buefy from 'buefy'
 import VueHead from 'vue-head'
 import 'buefy/dist/buefy.css'
 import 'bulma/css/bulma.min.css'
+import i18n from './i18n'
 
 import '@creativecommons/vocabulary/root.css'
 import '@creativecommons/vocabulary/vocabulary.css'
@@ -16,6 +17,7 @@ Vue.use(VueHead)
 
 /* eslint-disable no-new */
 new Vue({
+    i18n,
     el: '#app',
     components: { App },
     template: '<App/>'


### PR DESCRIPTION
Fixes #27

The integration of CC Chooser with Vocabulary was only partially complete in that two dependencies namely `vue-i18n` and `@kazupon/vue-i18n-loader` had not been installed. This PR installs these dependencies, sets up i18n with an example and thus resolves the issue of `$t` not being found.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
