### PR TITLE
add unit test for IconSelector.vue component

### DIFF
--- a/test/unit/specs/components/IconSelector.spec.js
+++ b/test/unit/specs/components/IconSelector.spec.js
@@ -1,0 +1,244 @@
+import { shallowMount } from "@vue/test-utils";
+import IconSelector from "@/components/IconSelector";
+
+function createConfig (overrides) {
+  const mocks = {};
+  const propsData = { };
+  return Object.assign({ mocks, propsData }, overrides);
+}
+
+describe("IconSelector.vue", () => {
+
+    describe('auto selection when mounting with different props', () => {
+        const SA_TEXT_WHEN_ENABLED = 'Not Require Distribution on Same Terms'.toLowerCase()
+        const SA_TEXT_WHEN_DISABLED = 'Require Disribution on Same Terms'.toLowerCase()
+
+        const NC_TEXT_WHEN_ENABLED = 'Allow Commercial Uses of Your Work'.toLowerCase()
+        const NC_TEXT_WHEN_DISABLED = 'Disallow Commercial Uses of Your Work'.toLowerCase()
+
+        const ND_TEXT_WHEN_ENABLED = 'Allow Others to Modify Your Work'.toLowerCase()
+        const ND_TEXT_WHEN_DISABLED = 'Disallow Modifications of Your Work'.toLowerCase()
+
+
+        describe('SA', () => {
+            it('auto selected when mounting with props { value: true }', () => {
+                const config = createConfig({
+                    propsData: {
+                        id: 'sa',
+                        icon: 'sa',
+                        value: true
+                    }
+                });
+        
+                const wrapper = shallowMount(IconSelector, config);
+                expect(wrapper.text().toLowerCase()).toContain(SA_TEXT_WHEN_ENABLED)
+            })
+    
+            it('not auto selected when mounting with props { value: false }', () => {
+                const config = createConfig({
+                    propsData: {
+                        id: 'sa',
+                        icon: 'sa',
+                        value: false
+                    }
+                });
+        
+                const wrapper = shallowMount(IconSelector, config);
+                expect(wrapper.text().toLowerCase()).toContain(SA_TEXT_WHEN_DISABLED)
+            })
+        })
+
+        describe('NC', () => {
+            it('not auto selected when mounting with props { value: true }', () => {
+                const config = createConfig({
+                    propsData: {
+                        id: 'nc',
+                        icon: 'nc',
+                        value: true
+                    }
+                });
+        
+                const wrapper = shallowMount(IconSelector, config);
+                expect(wrapper.text().toLowerCase()).toContain(NC_TEXT_WHEN_DISABLED)
+            })
+    
+            it('not auto selected when mounting with props { value: false }', () => {
+                const config = createConfig({
+                    propsData: {
+                        id: 'nc',
+                        icon: 'nc',
+                        value: false
+                    }
+                });
+        
+                const wrapper = shallowMount(IconSelector, config);
+                expect(wrapper.text().toLowerCase()).toContain(NC_TEXT_WHEN_DISABLED)
+            })
+        })
+
+        describe('ND', () => {
+            it('not auto selected when mounting with props { value: true }', () => {
+                const config = createConfig({
+                    propsData: {
+                        id: 'nd',
+                        icon: 'nd',
+                        value: true
+                    }
+                });
+        
+                const wrapper = shallowMount(IconSelector, config);
+                expect(wrapper.text().toLowerCase()).toContain(ND_TEXT_WHEN_DISABLED)
+            })
+    
+            it('not auto selected when mounting with props { value: false }', () => {
+                const config = createConfig({
+                    propsData: {
+                        id: 'nd',
+                        icon: 'nd',
+                        value: false
+                    }
+                });
+        
+                const wrapper = shallowMount(IconSelector, config);
+                expect(wrapper.text().toLowerCase()).toContain(ND_TEXT_WHEN_DISABLED)
+            })
+        })
+
+    })
+
+    describe('render description for each license', () => {
+        it('SA\'s description exist', () => {
+            const config = createConfig({
+                propsData: {
+                    id: 'sa',
+                    icon: 'sa',
+                }
+            });
+    
+            const wrapper = shallowMount(IconSelector, config);
+            expect(wrapper.find('.icon-description').text().length)
+                .toBeGreaterThan(0)
+        })
+
+        it('ND\'s description exist', () => {
+            const config = createConfig({
+                propsData: {
+                    id: 'nd',
+                    icon: 'nd',
+                }
+            });
+    
+            const wrapper = shallowMount(IconSelector, config);
+            expect(wrapper.find('.icon-description').text().length)
+                .toBeGreaterThan(0)
+        })
+
+        it('NC\'s description exist', () => {
+            const config = createConfig({
+                propsData: {
+                    id: 'nc',
+                    icon: 'nc',
+                }
+            });
+    
+            const wrapper = shallowMount(IconSelector, config);
+            expect(wrapper.find('.icon-description').text().length)
+                .toBeGreaterThan(0)
+        })
+
+        it('description must differs between licenses', () => {    
+            const ncWrapper = shallowMount(IconSelector, {
+                propsData: {
+                    id: 'nc',
+                    icon: 'nc',
+                }
+            });
+            const ncDescription = ncWrapper.find('.icon-description').text();
+
+            const ndWrapper = shallowMount(IconSelector, {
+                propsData: {
+                    id: 'nd',
+                    icon: 'nd',
+                }
+            });
+            const ndDescription = ndWrapper.find('.icon-description').text();
+
+            const saWrapper = shallowMount(IconSelector, {
+                propsData: {
+                    id: 'sa',
+                    icon: 'sa',
+                }
+            });
+            const saDescription = saWrapper.find('.icon-description').text();
+
+            expect(ncDescription).not.toEqual(ndDescription)
+            expect(ncDescription).not.toEqual(saDescription)
+            expect(saDescription).not.toEqual(ndDescription)
+        })
+    })
+
+    it('click on SA emits true then false', () => {
+        const wrapper = shallowMount(IconSelector, {
+            propsData: {
+                id: 'sa',
+                icon: 'sa',
+                value: false
+            }
+        });
+        const component = wrapper.find('#component');
+        component.trigger('click');
+        component.trigger('click');
+
+        expect(wrapper.emitted().input[0][0]).toBe(true)
+        expect(wrapper.emitted().input[1][0]).toBe(false)
+    })
+
+    it('click on SA emits false then true', () => {
+        const wrapper = shallowMount(IconSelector, {
+            propsData: {
+                id: 'sa',
+                icon: 'sa',
+                value: true
+            }
+        });
+        const component = wrapper.find('#component');
+        component.trigger('click');
+        component.trigger('click');
+
+        expect(wrapper.emitted().input[0][0]).toBe(false)
+        expect(wrapper.emitted().input[1][0]).toBe(true)
+    })
+
+    it('click on ND emits false then true', () => {
+        const wrapper = shallowMount(IconSelector, {
+            propsData: {
+                id: 'nd',
+                icon: 'nd',
+                value: true
+            }
+        });
+        const component = wrapper.find('#component');
+        component.trigger('click');
+        component.trigger('click');
+
+        expect(wrapper.emitted().input[0][0]).toBe(false)
+        expect(wrapper.emitted().input[1][0]).toBe(true)
+    })
+
+    it('click on NC emits false then true', () => {
+        const wrapper = shallowMount(IconSelector, {
+            propsData: {
+                id: 'nc',
+                icon: 'nc',
+                value: true
+            }
+        });
+        const component = wrapper.find('#component');
+        component.trigger('click');
+        component.trigger('click');
+
+        expect(wrapper.emitted().input[0][0]).toBe(false)
+        expect(wrapper.emitted().input[1][0]).toBe(true)
+    })
+
+});


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
add unit test for IconSelector.vue component

**Description**
<!-- Add your description below. -->
IconSelector.vue component is responsible for rendering the license, it accept:
- props: `{ id: String, icon: String , value: boolean }`
- click event which triggers input event with true or false.

**_example:_**
- props: `{ id: 'sa', icon: 'sa', value: 'true' }`
- click event.
**_result:_**
- triggers input event with false, which means unselect the SA license.

**_Note_**:
**default props:**
- SA's value could be true or false, which means it could be auto selected or no.
- NC and ND's value must be true when mounting the component.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
