### PR TITLE
Edit full license name in 'How Licenses are Communicated' modal to match the icons

### DIFF
--- a/src/components/HelpSection.vue
+++ b/src/components/HelpSection.vue
@@ -154,7 +154,7 @@
                     <tbody>
                     <tr>
                         <th>{{$t('help.how-licenses-communicated.full-name')}}</th>
-                        <td>{{$t('help.how-licenses-communicated.CC-BY-SA')}}</td>
+                        <td>{{$t('help.how-licenses-communicated.CC-BY-NC')}}</td>
                     </tr>
                     <tr>
                         <th>{{$t('help.how-licenses-communicated.short-name')}}</th>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -168,7 +168,7 @@
             "full-name": "Full Name",
             "short-name": "Short Name",
             "license-icons": "Icons",
-            "CC-BY-SA": "Creative Commons Attribution 4.0 International"
+            "CC-BY-NC": "Attribution-NonCommercial 4.0 International"
         },
         "considerations-before-licensing": {
             "heading": "Considerations Before Licensing",


### PR DESCRIPTION
Signed-off-by: Olga Bulat <obulat@gmail.com>

<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #100

**Description**
<!-- Add your description below. -->
Changed the full license name to 'Attribution-NonCommercial International 4.0'
**Other information**
<!-- Add any other information below or delete the "Other Information" line entirely. -->
License [Legal Code page](https://creativecommons.org/licenses/by-nc/4.0/legalcode) states the name of the license as 'Creative Commons Attribution-NonCommercial 4.0 International Public License', but the[ license information pages](https://creativecommons.org/licenses/by-nc/4.0/), that actually communicate to the public human-readable description of the license, only state 'Attribution-NonCommercial'. 

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
